### PR TITLE
Feature/id management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ set(COMPONENT_SRCS
         message.c
         response.c
         api-http-helper.c
+        keys.c
         )
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 set(COMPONENT_REQUIRES ubirch-protocol ubirch-esp32-key-storage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,6 @@ set(COMPONENT_SRCS
         api-http-helper.c
         )
 set(COMPONENT_ADD_INCLUDEDIRS ".")
-set(COMPONENT_REQUIRES ubirch-protocol ubirch-esp32-storage)
+set(COMPONENT_REQUIRES ubirch-protocol ubirch-esp32-key-storage)
 set(COMPONENT_PRIV_REQUIRES esp_http_client mbedtls)
 register_component()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following components are required for the functionality, see also
 [CMakeLists.txt](https://github.com/ubirch/ubirch-esp32-api-http/blob/master/CMakeLists.txt)
 
 - [ubirch-protocol](https://github.com/ubirch/ubirch-protocol.git)
-- [ubirch-esp32-storage](https://github.com/ubirch/ubirch-esp32-storage)
+- [ubirch-esp32-key-storage](https://github.com/ubirch/ubirch-esp32-key-storage)
 - [esp_http_client](https://github.com/espressif/esp-idf/tree/master/components/esp_http_client)
 
 ## Example
@@ -64,3 +64,7 @@ ubirch_send(CONFIG_UBIRCH_BACKEND_DATA_URL, sbuf->data, sbuf->size, &http_status
 ubirch_parse_backend_response(unpacker, bin_response_handler);
 // [...]
 ```
+
+To create, register a new key-pair or update an existing one use `create_keys`, `register_keys` or `update_keys` from [`keys.h`](https://github.com/ubirch/ubirch-esp32-api-http/blob/master/keys.h), for an [example](example) usage see [here](https://github.com/ubirch/example-esp32/blob/master/main/main.c).
+Note that all of these three functions change the state of the current ID context which is selected and modified by the
+functions from [`id_handling.h`](https://github.com/ubirch/ubirch-esp32-key-storage/blob/master/id_handling.h).

--- a/keys.c
+++ b/keys.c
@@ -1,0 +1,272 @@
+/*!
+ * @file    keys.c
+ * @brief   key and signature helping functions
+ *
+ * @author Waldemar Gruenwald
+ * @date   2018-10-10
+ *
+ * @copyright &copy; 2018 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <esp_err.h>
+#include <time.h>
+#include <esp_log.h>
+#include <ubirch_api.h>
+
+#include "ubirch_ed25519.h"
+#include "ubirch_protocol_kex.h"
+#include "ubirch_protocol.h"
+
+#include "id_handling.h"
+#include "keys.h"
+
+#include <mbedtls/base64.h>
+
+//#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+
+#define KEY_LIFETIME_IN_SECONDS (60 * 60 * 24 * 365 * CONFIG_UBIRCH_KEY_LIFETIME_YEARS)
+#define KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS (60 * 60 * 24 * 7) // one week
+
+#define STR(x) #x
+#define VALUE_STRING(x) STR(x)
+#pragma message ("Key lifetime at creation and update is set to " \
+        VALUE_STRING(CONFIG_UBIRCH_KEY_LIFETIME_YEARS) " year(s)")
+
+#define BYTES_LENGTH_TO_BASE64_STRING_LENGTH(__len) (((__len + 2) / 3) * 4)
+
+static const char *TAG = "KEY_HANDLING";
+
+/*!
+ * Create a new signature Key pair for the current ID context
+ */
+void create_keys(void) {
+    ESP_LOGI(TAG, "create keys");
+    // create the key pair
+    unsigned char secret_key[crypto_sign_SECRETKEYBYTES];
+    unsigned char public_key[crypto_sign_PUBLICKEYBYTES];
+    crypto_sign_keypair(public_key, secret_key);
+    ESP_LOGD(TAG, "publicKey");
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, (const char *) (public_key), crypto_sign_PUBLICKEYBYTES, ESP_LOG_DEBUG);
+
+    ubirch_public_key_set(public_key, sizeof(public_key));
+    ubirch_secret_key_set(secret_key, sizeof(secret_key));
+
+    unsigned char* uuid = NULL;
+    size_t uuid_len = 0;
+    ubirch_uuid_get(&uuid, &uuid_len);
+
+    // create key registration info
+    ubirch_key_info info = {};
+    info.algorithm = (char *) (UBIRCH_KEX_ALG_ECC_ED25519);
+    info.created = (unsigned int) time(NULL);                           // current time of the system
+    memcpy(info.hwDeviceId, uuid, uuid_len);                        // 16 Byte unique hardware device ID
+    memcpy(info.pubKey, public_key, sizeof(public_key));// the public key
+    info.validNotAfter = (unsigned int) (time(NULL) +
+                                         KEY_LIFETIME_IN_SECONDS);      // time until the key will be valid (now + 1 year)
+    info.validNotBefore = (unsigned int) time(NULL);                    // time from when the key will be valid (now)
+
+    // create protocol context
+    ubirch_protocol *upp = ubirch_protocol_new(uuid, ed25519_sign);
+
+    // create the certificate for the key pair
+    ubirch_protocol_message(upp, proto_signed, UBIRCH_PROTOCOL_TYPE_REG, (const char *) &info, sizeof(info));
+
+    // store certificate in flash
+    if (ubirch_certificate_store(upp->data, upp->size) != ESP_OK) {
+        ESP_LOGW(TAG, "key certificate could not be stored in flash");
+    }
+
+    // free allocated resources
+    ubirch_protocol_free(upp);
+
+    ubirch_id_state_set(UBIRCH_ID_STATE_KEYS_CREATED, true);
+    ubirch_id_state_set(UBIRCH_ID_STATE_KEYS_REGISTERED, false);
+    ubirch_next_key_update_set(info.validNotAfter - KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS);
+}
+
+
+/*!
+ * Register the Keys of the current ID context in the backend.
+ */
+esp_err_t register_keys(void) {
+    ESP_LOGI(TAG, "register identity");
+
+    msgpack_sbuffer *sbuf = msgpack_sbuffer_new();
+
+    ESP_LOGD(TAG, "sbuf size: %d", (int)sbuf->size);
+
+    if (ubirch_certificate_load(&sbuf->data, &sbuf->size) != ESP_OK) {
+        ESP_LOGE(TAG, "error loaded certificate");
+        msgpack_sbuffer_free(sbuf);
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, "sbuf size: %d", (int)sbuf->size);
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, (const char *) (sbuf->data), sbuf->size, ESP_LOG_DEBUG);
+
+    unsigned char* uuid = NULL;
+    size_t uuid_len = 0;
+    ubirch_uuid_get(&uuid, &uuid_len);
+
+    // send the data
+    // TODO: verify response
+    int http_status;
+    esp_err_t ret = ESP_FAIL;
+    if (ubirch_send(CONFIG_UBIRCH_BACKEND_KEY_SERVER_URL, uuid, sbuf->data, sbuf->size, &http_status, NULL, NULL)
+            == UBIRCH_SEND_OK) {
+        if (http_status == 200) {
+            ESP_LOGI(TAG, "successfull sent registration");
+            ubirch_id_state_set(UBIRCH_ID_STATE_KEYS_REGISTERED, true);
+            if (ubirch_certificate_remove()) {
+                ESP_LOGW(TAG, "unable to delete certificate");
+            }
+            ret = ESP_OK;
+        } else {
+            ESP_LOGE(TAG, "unable to send registration (%d)", http_status);
+        }
+    } else {
+        ESP_LOGE(TAG, "error while sending registration");
+    }
+    msgpack_sbuffer_free(sbuf);
+    return ret;
+}
+
+
+/*!
+ * Update the Keys of the current ID context in the backend.
+ */
+esp_err_t update_keys(void) {
+    // get time information
+    time_t now = time(NULL);
+
+    // create new keys
+    unsigned char new_ed25519_secret_key[crypto_sign_SECRETKEYBYTES] = {};
+    unsigned char new_ed25519_public_key[crypto_sign_PUBLICKEYBYTES] = {};
+    crypto_sign_keypair(new_ed25519_public_key, new_ed25519_secret_key);
+
+    // convert keys into base64 format
+    unsigned char* ed25519_public_key_old = NULL;
+    size_t len = 0;
+    if (ubirch_public_key_get(&ed25519_public_key_old, &len)) {
+        ESP_LOGW(TAG, "failed to load old pub");
+        return ESP_FAIL;
+    }
+    char old_pubKey[BYTES_LENGTH_TO_BASE64_STRING_LENGTH(crypto_sign_PUBLICKEYBYTES) + 1];
+    unsigned int outputlen = 0;
+    if (mbedtls_base64_encode((unsigned char*)old_pubKey, sizeof(old_pubKey),
+                &outputlen, ed25519_public_key_old, len) != 0) {
+        ESP_LOGW(TAG, "failed to convert old pub key to base64");
+        return ESP_FAIL;
+    }
+    char new_pubKey[BYTES_LENGTH_TO_BASE64_STRING_LENGTH(crypto_sign_PUBLICKEYBYTES) + 1];
+    outputlen = 0;
+    if (mbedtls_base64_encode((unsigned char*)new_pubKey, sizeof(new_pubKey),
+                &outputlen, new_ed25519_public_key, crypto_sign_PUBLICKEYBYTES) != 0) {
+        ESP_LOGW(TAG, "failed to convert new pub key to base64");
+        return ESP_FAIL;
+    }
+
+    unsigned char* uuid = NULL;
+    size_t uuid_len = 0;
+    ubirch_uuid_get(&uuid, &uuid_len);
+
+    // build update json string
+    ubirch_update_key_info update_info = {
+        .algorithm = UBIRCH_KEX_ALG_ECC_ED25519,
+        .created = now,
+        .hwDeviceId = uuid,
+        .pubKey = new_pubKey,
+        .prevPubKeyId = old_pubKey,
+        .validNotAfter = now + KEY_LIFETIME_IN_SECONDS,
+        .validNotBefore = now
+    };
+
+    ESP_LOGD(TAG, "validNotBefore: %ld", update_info.validNotBefore);
+    ESP_LOGD(TAG, "validNotAfter: %ld", update_info.validNotAfter);
+
+    // init with outer brace
+    char json_string[610] = "{\"pubKeyInfo\":";
+    char *inner_json_string = json_string + strlen(json_string);
+    size_t inner_json_string_size = json_pack_key_update(&update_info, inner_json_string,
+            sizeof(json_string) - strlen(json_string));
+    ESP_LOGD(TAG, "inner json string size: %d", inner_json_string_size);
+    ESP_LOGD(TAG, "inner json string: %s", inner_json_string);
+
+    // sign json with old key
+    unsigned char signature_old[crypto_sign_BYTES];
+    if (ed25519_sign((unsigned char*)inner_json_string, inner_json_string_size, signature_old) != 0) {
+        ESP_LOGW(TAG, "failed to sign with old key");
+        return ESP_FAIL;
+    }
+    char signature_old_base64[BYTES_LENGTH_TO_BASE64_STRING_LENGTH(crypto_sign_BYTES) + 1];
+    outputlen = 0;
+    if (mbedtls_base64_encode((unsigned char*)signature_old_base64, sizeof(signature_old_base64),
+                &outputlen, signature_old, crypto_sign_BYTES) != 0) {
+        ESP_LOGW(TAG, "failed to convert signature to base64");
+        return ESP_FAIL;
+    }
+    // sign json with new key
+    unsigned char signature_new[crypto_sign_BYTES];
+    if (ed25519_sign_key((unsigned char*)inner_json_string, inner_json_string_size, signature_new,
+                new_ed25519_secret_key) != 0) {
+        ESP_LOGW(TAG, "failed to sign with new key");
+        return ESP_FAIL;
+    }
+    char signature_new_base64[BYTES_LENGTH_TO_BASE64_STRING_LENGTH(crypto_sign_BYTES) + 1];
+    outputlen = 0;
+    if (mbedtls_base64_encode((unsigned char*)signature_new_base64, sizeof(signature_new_base64),
+                &outputlen, signature_new, crypto_sign_BYTES) != 0) {
+        ESP_LOGW(TAG, "failed to convert signature to base64");
+        return ESP_FAIL;
+    }
+    // add signatures to json string
+    char *string_index = inner_json_string + inner_json_string_size;
+    string_index += sprintf(string_index, ",\"signature\":\"%s\",\"prevSignature\":\"%s\"}",
+            signature_new_base64, signature_old_base64);
+    size_t json_string_size = string_index - json_string;
+    ESP_LOGD(TAG, "update key json length: %d", json_string_size);
+    ESP_LOGD(TAG, "update key json: %s", json_string);
+
+    // send data
+    int http_status;
+    if (ubirch_send_json(CONFIG_UBIRCH_BACKEND_UPDATE_KEY_SERVER_URL, uuid,
+                json_string, json_string_size, &http_status, NULL, NULL)
+            == UBIRCH_SEND_OK) {
+        if (http_status == 200) {
+            ESP_LOGI(TAG, "successfull sent key update");
+            if (ubirch_public_key_set(new_ed25519_public_key, crypto_sign_PUBLICKEYBYTES) != ESP_OK
+                    || ubirch_secret_key_set(new_ed25519_secret_key, crypto_sign_SECRETKEYBYTES) != ESP_OK) {
+                ESP_LOGW(TAG, "failed to set new key pair after registration");
+                return ESP_FAIL;
+            }
+        } else {
+            ESP_LOGW(TAG, "unable to send key update, http response is: %d", http_status);
+            return ESP_FAIL;
+        }
+    } else {
+        ESP_LOGW(TAG, "error while sending key update");
+        return ESP_FAIL;
+    }
+
+    ubirch_id_state_set(UBIRCH_ID_STATE_KEYS_CREATED, true);
+    ubirch_id_state_set(UBIRCH_ID_STATE_KEYS_REGISTERED, true);
+    ubirch_next_key_update_set(update_info.validNotAfter - KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS);
+
+    return ESP_OK;
+}

--- a/keys.h
+++ b/keys.h
@@ -1,0 +1,70 @@
+/*!
+ * @file    keys.h
+ * @brief   key and signature helping functions
+ *
+ * @author Waldemar Gruenwald
+ * @date   2018-10-10
+ *
+ * @copyright &copy; 2018 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+
+
+#ifndef KEYS_H
+#define KEYS_H
+
+#include <string.h>
+#include "ubirch_ed25519.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// length of base64 string is ceil(number_of_bytes / 3) * 4
+// to get ceil for value / 3 (value >= 0) we use (value + 2) / 3
+#define PUBLICKEY_BASE64_STRING_LENGTH (((crypto_sign_PUBLICKEYBYTES + 2) / 3) * 4)
+
+extern unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES];
+
+/*!
+ * Create a new signature Key pair for the current ID context.
+ *
+ * After creating the key pair, it is packad into msgpack together with aditional
+ * information, according to the structure `ubirch_key_info()`, from `ubirch_protocol_kex.h`,
+ * which is part of the `ubirch-protocol` module.
+ */
+void create_keys(void);
+
+/*!
+ * Register the Keys of the current ID context in the backend.
+ *
+ * This function can only be executed, if a network connection is available.
+ */
+esp_err_t register_keys(void);
+
+/*!
+ * Update the Keys of the current ID context in the backend.
+ *
+ * This function can only be executed, if a network connection is available.
+ */
+int update_keys(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KEYS_H */

--- a/message.c
+++ b/message.c
@@ -36,28 +36,6 @@
 
 static const char *TAG = "MESSAGE";
 
-esp_err_t ubirch_load_signature(unsigned char **signature, size_t *len) {
-    esp_err_t err;
-
-    err = kv_load("sign_storage", "signature", (void **) signature, len);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "error loading the last signature");
-    }
-
-    return err;
-}
-
-esp_err_t ubirch_store_signature(unsigned char *signature, size_t len) {
-    esp_err_t err;
-
-    err = kv_store("sign_storage", "signature", signature, len);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "error storing the signature");
-    }
-
-    return err;
-}
-
 esp_err_t *ubirch_message(ubirch_protocol *upp, int32_t *values, uint16_t num) {
     // load the signature of the previously sent message and copy it to the protocol context
     unsigned char *last_signature = NULL;

--- a/message.h
+++ b/message.h
@@ -31,26 +31,6 @@
 #include <ubirch_protocol.h>
 
 /*!
- * Store the signature in non-volatile memory to save it for the next message.
- *
- * @param signature the signature byte array
- * @param len the length of the signature
- * @return ESP_OK or an error code
- */
-esp_err_t ubirch_store_signature(unsigned char *signature, size_t len);
-
-/*!
- * Load the last stored signature from non-volatile memory.
- * This function internally allocates the memory required for the signature. Needs to be freed
- * after use.
- *
- * @param signature a pointer to the target signature pointer
- * @param len a pointer to a length variable where the loaded length is stored in
- * @return ESP_OK or an error code
- */
-esp_err_t ubirch_load_signature(unsigned char **signature, size_t *len);
-
-/*!
  * Create a new ubirch API message from the UUID and an array of sensor values.
  * This function will implicitely load the signature of the previous message and store
  * the signature of this created protocol message.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS ".."
-                       REQUIRES unity ubirch-protocol ubirch-esp32-storage
+                       REQUIRES unity ubirch-protocol ubirch-esp32-key-storage
                        PRIV_REQUIRES mbedtls)

--- a/test/test_keys.c
+++ b/test/test_keys.c
@@ -1,0 +1,41 @@
+#include "unity.h"
+#include <time.h>
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#include <esp_log.h>
+#include "keys.h"
+#include "id_handling.h"
+#include "storage.h"
+#include "ubirch_ed25519.h"
+
+static const char *TAG = "UBIRCH API TEST KEYS";
+
+TEST_CASE("create_keys", "[keys]")
+{
+    init_nvs();
+
+    unsigned char uuid[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_id_context_add("test_id_3"));
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_uuid_set(uuid, sizeof(uuid)));
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_id_context_store());
+    create_keys();
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_id_context_store());
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_id_context_load("test_id_3"));
+
+    time_t next_update;
+    TEST_ASSERT_EQUAL_INT(ESP_OK, ubirch_next_key_update_get(&next_update));
+    ESP_LOGD(TAG, "next update from mem: %ld", next_update);
+
+    TEST_ASSERT(ubirch_id_state_get(UBIRCH_ID_STATE_KEYS_CREATED));
+    TEST_ASSERT(!ubirch_id_state_get(UBIRCH_ID_STATE_KEYS_REGISTERED));
+    TEST_ASSERT(!ubirch_id_state_get(UBIRCH_ID_STATE_PASSWORD_SET));
+    TEST_ASSERT(!ubirch_id_state_get(UBIRCH_ID_STATE_PREVIOUS_SIGNATURE_SET));
+
+    // check if key pair works
+    unsigned char signature[crypto_sign_BYTES];
+    unsigned char data[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    TEST_ASSERT_EQUAL_INT(0, ed25519_sign(data, sizeof(data), signature));
+    TEST_ASSERT_EQUAL_INT(0, ed25519_verify(data, sizeof(data), signature));
+}

--- a/test/test_response.c
+++ b/test/test_response.c
@@ -7,6 +7,7 @@
 #include "storage.h"
 #include "ubirch_protocol.h"
 #include <ubirch_ed25519.h>
+#include "id_handling.h"
 
 static const char *TAG = "UBIRCH API TEST RESPONSE";
 
@@ -141,16 +142,17 @@ TEST_CASE("simple", "[response]")
     };
 
     init_nvs();
+    ubirch_id_context_add("default");
     // store previous signature
     unsigned char* prev_sig = (unsigned char*)data0 + PREVIOUS_SIGNATURE_START;
-    ubirch_store_signature(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
+    ubirch_previous_signature_set(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
     // test message
     TEST_ASSERT_EQUAL_INT(UBIRCH_ESP32_API_HTTP_RESPONSE_SUCCESS,
             test_ubirch_parse_backend_response(data0, sizeof(data0), ed25519_verify_signature_from_device_test));
 
     // store previous signature
     prev_sig = (unsigned char*)data1 + PREVIOUS_SIGNATURE_START;
-    ubirch_store_signature(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
+    ubirch_previous_signature_set(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
     // test message
     TEST_ASSERT_EQUAL_INT(UBIRCH_ESP32_API_HTTP_RESPONSE_SUCCESS,
             test_ubirch_parse_backend_response(data1, sizeof(data1), ed25519_verify_signature_from_backend_test));
@@ -197,7 +199,7 @@ TEST_CASE("wrong data", "[response]")
     memcpy(prev_sig, data1 + PREVIOUS_SIGNATURE_START, UBIRCH_PROTOCOL_SIGN_SIZE);
     // break previous signature in data
     prev_sig[7]++;
-    ubirch_store_signature(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
+    ubirch_previous_signature_set(prev_sig, UBIRCH_PROTOCOL_SIGN_SIZE);
 
 
     // test message

--- a/ubirch_api.c
+++ b/ubirch_api.c
@@ -31,6 +31,7 @@
 #include <ubirch_protocol.h>
 #include "ubirch_api.h"
 #include "mbedtls/base64.h"
+#include "id_handling.h"
 
 static const char *TAG = "UBIRCH API";
 //#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
@@ -124,7 +125,13 @@ ubirch_send_err_t ubirch_send(const char *url, const unsigned char *uuid, const 
 #ifdef CONFIG_UBIRCH_AUTH
     char uuid_string[37];
     uuid_to_string(uuid, uuid_string, sizeof(uuid_string));
-    char *auth_string = auth_to_base64(CONFIG_UBIRCH_AUTH);
+
+    char *auth_string_raw = NULL;
+    size_t auth_string_raw_size = 0;
+    ubirch_password_get(&auth_string_raw, &auth_string_raw_size);
+
+    char *auth_string = auth_to_base64(auth_string_raw);
+    ESP_LOGD(TAG, "AUTH %s", auth_string);
 
     esp_http_client_set_header(client, "Content-Type", "application/octet-stream");
     esp_http_client_set_header(client, "X-Ubirch-Hardware-Id", uuid_string);

--- a/ubirch_api.c
+++ b/ubirch_api.c
@@ -122,7 +122,7 @@ ubirch_send_err_t ubirch_send(const char *url, const unsigned char *uuid, const 
     // POST
     esp_http_client_set_url(client, url);
     esp_http_client_set_method(client, HTTP_METHOD_POST);
-#ifdef CONFIG_UBIRCH_AUTH
+
     char uuid_string[37];
     uuid_to_string(uuid, uuid_string, sizeof(uuid_string));
 
@@ -137,7 +137,7 @@ ubirch_send_err_t ubirch_send(const char *url, const unsigned char *uuid, const 
     esp_http_client_set_header(client, "X-Ubirch-Hardware-Id", uuid_string);
     esp_http_client_set_header(client, "X-Ubirch-Credential", auth_string);
     esp_http_client_set_header(client, "X-Ubirch-Auth-Type", "ubirch");
-#endif
+
     esp_http_client_set_post_field(client, data, (int) (length));
     esp_err_t err = esp_http_client_perform(client);
     ubirch_send_err_t return_code = UBIRCH_SEND_OK;
@@ -153,9 +153,8 @@ ubirch_send_err_t ubirch_send(const char *url, const unsigned char *uuid, const 
         return_code = UBIRCH_SEND_ERROR;
     }
     esp_http_client_cleanup(client);
-#ifdef CONFIG_UBIRCH_AUTH
     free(auth_string);
-#endif
+
     return return_code;
 }
 


### PR DESCRIPTION
This PR add the functions `create_keys` and `register_keys` (moved here from ubirch-esp32-key-storage) and makes use of id_handling functions from ubirch-esp32-key-storage.